### PR TITLE
Allocate a pseudo-TTY to allow the container to receive signals from the user

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -33,6 +33,7 @@ pub fn run(
   debug!("Creating container...");
   let mut create_command = Command::new("docker");
   create_command.arg("create");
+  create_command.arg("--tty"); // [tag:tty]
   create_command.arg(from_image);
   create_command.arg("/bin/sh");
   create_command.arg("-c");


### PR DESCRIPTION
Allocate a pseudo-TTY to allow the container to receive signals from the user.

**Status:** Ready

**Fixes:** N/A
