### PR TITLE
Use -v instead of -V as shorthand for --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ USAGE:
 FLAGS:
     -h, --help       Prints help information
     -s, --shell      Drops you into a shell after the tasks are complete
-    -V, --version    Prints version information
+    -v, --version    Prints version information
 
 OPTIONS:
-    -f, --file <PATH>    Sets the path to the bakefile (default: bake.yml)
+    -f, --file <PATH>    Sets the path to the bakefile (default:
+                         bake.yml)
 
 ARGS:
     <TASKS>...    Sets the tasks to run

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ struct Settings {
 fn settings() -> Settings {
   let matches = App::new("Bake")
     .version("0.1.0")
+    .version_short("v")
     .author("Stephan Boyer <stephan@stephanboyer.com>")
     .about("Bake is a containerized build system.")
     .arg(


### PR DESCRIPTION
Use `-v` instead of `-V` as shorthand for `--version`.

**Status:** Ready

**Fixes:** N/A
