### PR TITLE
Use the new Docker CLI subcommands, document the minimum Docker version, and use `--init` when creating containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ tasks:
     user: user
     command: cargo test
 ```
+
+## Dependencies
+
+Bake requires Docker Engine 17.03.0 or later.


### PR DESCRIPTION
Use the new Docker CLI subcommands, document the minimum Docker version, and use `--init` when creating containers.

**Status:** Ready

**Fixes:** N/A
