### PR TITLE
Remove GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,0 @@
-[Description of the issue]
-
-# Steps to reproduce
-You can omit this section if not applicable.
-
-1. [First step]
-2. [Second step]
-3. [and so on...]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-[Description of the change]
-
-**Status:** Ready / In development
-
-**Fixes:** Link to issue (if applicable)


### PR DESCRIPTION
Remove GitHub templates. GitHub has a new mechanism for templates that we can try.

**Status:** Ready

**Fixes:** N/A
