### PR TITLE
Properly handle SIGINT and SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,6 @@ dependencies = [
 name = "bake"
 version = "0.2.0"
 dependencies = [
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-atty = "0.2"
 dirs = "1"
 env_logger = "0.6"
 hex = "0.3"
@@ -26,7 +25,7 @@ textwrap = "0.11"
 
 [dependencies.ctrlc]
 version = "3"
-features = ["termination"]
+features = ["termination"] # [tag:ctrlc_term]
 
 [dependencies.clap]
 version = "2"


### PR DESCRIPTION
Properly handle `SIGINT` and `SIGTERM`. We treat both signals identically: stop any active containers and set a flag to prevent Bake from attempting to run any more tasks. Then the usual cleanup code will take care of the rest (deleting containers and images as necessary).

This PR also removes the `--tty` option for Docker (we still keep it for the `--shell` feature, however). There are a few factors that went into this decision:
1. When the user hits `CTRL-C` when Docker is running with `--tty`, there is a race between Docker and Bake to stop the container. This can lead to an awkward (but harmless) error message about Bake being unable to stop the container (since Docker stopped it first), which I encountered during an embarrassing live demo this past Monday. We could have Bake not try to stop the container on `SIGINT` (and just let Docker do it), but we still want it to stop the container on `SIGTERM` (since Docker won't do it in this case). I think it's simpler to handle both signals identically.
2. Previously the behavior was to run Docker with `--tty` if and only if Bake itself was invoked from a terminal. This means the user gets to see nice colored output when running Bake from their terminal, but that makes Bake jobs less reproducible. We should always use `--tty` or never use it for maximum reproducibility.
3. We don't want programs running in the container asking the user for input because they observe that they are attached to a TTY. Bake jobs are supposed to be non-interactive for reproducibility.

@juliahw