### PR TITLE
Use the root user's shell rather than /bin/sh for --shell

### DIFF
--- a/bake.yml
+++ b/bake.yml
@@ -8,6 +8,7 @@ tasks:
     dependencies:
       - packages
     command: |
+      set -o pipefail
       curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | sh
 
   user: useradd --user-group --create-home user
@@ -18,6 +19,7 @@ tasks:
       - user
     user: user
     command: |
+      set -o pipefail
       curl https://sh.rustup.rs -sSf | sh -s -- -y
       . $HOME/.cargo/env
       rustup component add clippy

--- a/bake.yml
+++ b/bake.yml
@@ -11,7 +11,7 @@ tasks:
       set -o pipefail
       curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | sh
 
-  user: useradd --user-group --create-home user
+  user: adduser --disabled-password --gecos '' user
 
   rust:
     dependencies:

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn set_up_signal_handlers(
       let _ = stdout().write(b"\n");
       info!("Terminating...");
 
-      // Stop any active containers. The unwrap will only fail if a panic
+      // Stop any active containers. The `unwrap` will only fail if a panic
       // already occurred.
       for container in &*active_containers_ref.lock().unwrap() {
         if let Err(e) = runner::stop_container(&container) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,11 +86,10 @@ fn set_up_logging() {
   .init();
 }
 
-// Set up the signal handlers. Returns a reference to a Boolean indicating
-// whether the user requested graceful termination.
+// Set up the signal handlers.
 fn set_up_signal_handlers(
-  running: &Arc<AtomicBool>,
-  active_containers: &Arc<Mutex<HashSet<String>>>,
+  running: Arc<AtomicBool>,
+  active_containers: Arc<Mutex<HashSet<String>>>,
 ) -> Result<(), String> {
   // If STDOUT is a TTY, the process will receive a SIGINT when
   // the user types CTRL+C at the terminal. The default behavior is to crash
@@ -98,12 +97,9 @@ fn set_up_signal_handlers(
   // before terminating, so we trap the signal here. This code also traps
   // SIGTERM, because we compile the `ctrlc` crate with the `termination`
   // feature [ref:ctrlc_term].
-  let running_ref: Arc<AtomicBool> = running.clone();
-  let active_containers_ref: Arc<Mutex<HashSet<String>>> =
-    active_containers.clone();
   ctrlc::set_handler(move || {
     // Let the rest of the program know the user wants to quit.
-    if running_ref.swap(false, Ordering::SeqCst) {
+    if running.swap(false, Ordering::SeqCst) {
       // Acknowledge the request to quit. We may have been in the middle of
       // printing a line of output, so here we print a newline before emitting
       // the log message.
@@ -112,7 +108,7 @@ fn set_up_signal_handlers(
 
       // Stop any active containers. The `unwrap` will only fail if a panic
       // already occurred.
-      for container in &*active_containers_ref.lock().unwrap() {
+      for container in &*active_containers.lock().unwrap() {
         if let Err(e) = runner::stop_container(&container) {
           error!("{}", e);
         }
@@ -542,8 +538,8 @@ fn run_tasks<'a>(
       &to_image.borrow(),
       &env,
       tar_file,
-      running,
-      active_containers,
+      &running,
+      &active_containers,
     )?;
 
     // If the user wants to stop the job, quit now.
@@ -593,7 +589,7 @@ fn entry() -> Result<(), String> {
   let active_containers = Arc::new(Mutex::new(HashSet::<String>::new()));
 
   // Set up the signal handlers.
-  set_up_signal_handlers(&running, &active_containers)?;
+  set_up_signal_handlers(running.clone(), active_containers.clone())?;
 
   // Parse the command-line arguments;
   let settings = settings()?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -87,7 +87,8 @@ pub fn run<R: Read>(
   debug!("Created container `{}`.", container_id);
 
   {
-    // If the user interrupts the program, kill the container.
+    // If the user interrupts the program, kill the container. The `unwrap`
+    // will only fail if a panic already occurred.
     active_containers
       .lock()
       .unwrap()
@@ -221,7 +222,8 @@ pub fn spawn_shell(image: &str) -> Result<(), String> {
       "--tty",
       "--init", // [ref:--init]
       image,
-      "/bin/sh",
+      "/bin/su", // We use `su` rather than `sh` to use the root user's shell.
+      "-l",
     ],
     "The shell exited with a failure.",
   )


### PR DESCRIPTION
Use the `root` user's shell rather than `/bin/sh` for `--shell`. I also updated some comments, changed some ownership, and added `set -o pipefail` for tasks in the bakefile that use pipes.