### PR TITLE
Remove the short form for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Let's create a simple bakefile. Create a file named `bake.yml` with the followin
 ```yaml
 image: ubuntu
 tasks:
-  greet: echo 'Hello, World!'
+  greet:
+    command: echo 'Hello, World!'
 ```
 
 Now run `bake`. You should see the following:
@@ -259,21 +260,6 @@ paths: []          # Paths to copy into the container
 location: /scratch # Path in the container for running this task
 user: root         # Name of the user in the container for running this task
 command: null      # Shell command to run in the container
-```
-
-For convenience, a task can be a string rather than an object. The resulting task uses that string as its `command`, with the other fields set to their defaults. So the following two bakefiles are equivalent:
-
-```yaml
-image: alpine
-tasks:
-  greet: echo 'Hello, World!'
-```
-
-```yaml
-image: alpine
-tasks:
-  greet:
-    command: echo 'Hello, World!'
 ```
 
 The [bakefile](https://github.com/stepchowfun/bake/blob/master/bake.yml) for Bake itself is a comprehensive real-world example.

--- a/bake.yml
+++ b/bake.yml
@@ -1,8 +1,9 @@
 image: ubuntu:18.04
 tasks:
-  packages: |
-    apt-get update
-    apt-get install --yes build-essential curl
+  packages:
+    command: |
+      apt-get update
+      apt-get install --yes build-essential curl
 
   tagref:
     dependencies:
@@ -11,7 +12,8 @@ tasks:
       set -o pipefail
       curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | VERSION=0.0.8 sh
 
-  user: adduser --disabled-password --gecos '' user
+  user:
+    command: adduser --disabled-password --gecos '' user
 
   rust:
     dependencies:


### PR DESCRIPTION
Remove the short form for tasks. I hate to do this, but Serde's error messages for sum types are unacceptably useless:

```sh
$ bake
[ERROR] Unable to parse file `bake.yml`. Details: tasks: data did not match any variant of untagged enum
        RawTask at line 3 column 11
```

This message gives no information about why none of the variants matched, and also I don't want user-facing error messages referring to internal identifiers from the source code. Maybe one day I can invest in contributing an upstream fix. But that day is not today.

See https://github.com/serde-rs/serde/issues/773.