### PR TITLE
Don't run commands with a login shell

### DIFF
--- a/bake.yml
+++ b/bake.yml
@@ -41,13 +41,17 @@ tasks:
       - Cargo.toml
       - src
     user: user
-    command: cargo build
+    command: |
+      . $HOME/.cargo/env
+      cargo build
 
   test:
     dependencies:
       - tools
     user: user
-    command: cargo test
+    command:
+      . $HOME/.cargo/env
+      cargo test
 
   lint:
     dependencies:
@@ -56,6 +60,7 @@ tasks:
       - rustfmt.toml
     user: user
     command: |
+      . $HOME/.cargo/env
       cargo fmt --all -- --check
       cargo clippy -- --deny clippy::pedantic
       tagref


### PR DESCRIPTION
Don't run commands with a login shell. This fixes the `mesg: ttyname failed: Inappropriate ioctl for device` problem and makes tasks faster. However, this also makes some tasks less convenient to write because one can no longer rely on the startup files (`.profile` etc.) being loaded.