### PR TITLE
Improve the messaging when there are no tasks to run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -615,16 +615,18 @@ fn entry() -> Result<(), String> {
 
   // Compute a schedule of tasks to run.
   let schedule = schedule::compute(&bakefile, &root_tasks);
-  info!(
-    "The following tasks will be executed in the order given: {}.",
-    format::series(
-      schedule
-        .iter()
-        .map(|task| format!("`{}`", task))
-        .collect::<Vec<_>>()
-        .as_ref()
-    )
-  );
+  if !schedule.is_empty() {
+    info!(
+      "The following tasks will be executed in the order given: {}.",
+      format::series(
+        schedule
+          .iter()
+          .map(|task| format!("`{}`", task))
+          .collect::<Vec<_>>()
+          .as_ref()
+      )
+    );
+  }
 
   // Fetch all the environment variables used by the tasks in the schedule.
   let env = fetch_env(&schedule, &bakefile.tasks)?;


### PR DESCRIPTION
Improve the messaging when there are no tasks to run. Thanks @juliahw for pointing this out!

Before:

```sh
$ bake
[INFO] The following tasks will be executed in
       the order given: .
[INFO] 0 tasks finished.
```

After:

```sh
$ bake
[INFO] 0 tasks finished.
```

I think this can still be improved, but at least now there aren't any egregiously formatted messages.