### PR TITLE
Don't render commands

### DIFF
--- a/bake.yml
+++ b/bake.yml
@@ -1,21 +1,21 @@
 image: ubuntu:18.04
 tasks:
   install_packages:
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       apt-get update
       apt-get install --yes build-essential curl
 
   install_tagref:
     dependencies:
       - install_packages
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | VERSION=1.1.0 sh
 
   create_user:
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       adduser --disabled-password --gecos '' user
 
   install_rust:
@@ -23,8 +23,8 @@ tasks:
       - install_packages
       - create_user
     user: user
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable-2019-04-25-x86_64-unknown-linux-gnu
       . $HOME/.cargo/env
       rustup component add clippy
@@ -43,8 +43,8 @@ tasks:
       - Cargo.lock
       - Cargo.toml
     user: user
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       . $HOME/.cargo/env
       mv Cargo.lock Cargo.lock.og
       mv Cargo.toml Cargo.toml.og
@@ -61,8 +61,8 @@ tasks:
     input_paths:
       - src
     user: user
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       . $HOME/.cargo/env
       cargo build
 
@@ -70,8 +70,8 @@ tasks:
     dependencies:
       - build
     user: user
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       . $HOME/.cargo/env
       cargo test
 
@@ -83,8 +83,8 @@ tasks:
       - clippy.toml # Used by `cargo clippy`
       - rustfmt.toml # Used by `cargo fmt`
     user: user
-    command: |
-      set -euxo pipefail
+    command: |-
+      set -euo pipefail
       . $HOME/.cargo/env
       cargo fmt --all -- --check
       cargo clippy -- --deny clippy::pedantic

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,4 @@
 use crate::{bakefile::Task, docker};
-use colored::Colorize;
 use std::{
   collections::{HashMap, HashSet},
   io::Read,
@@ -85,8 +84,6 @@ pub fn run<R: Read>(
         shell_escape(&command),
         shell_escape(&task.user)
       ));
-
-      eprintln!("{}", command.bold());
     }
 
     // Create the container.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -86,7 +86,7 @@ pub fn run<R: Read>(
         shell_escape(&task.user)
       ));
 
-      eprintln!("{}", command.blue());
+      eprintln!("{}", command.bold());
     }
 
     // Create the container.


### PR DESCRIPTION
Render commands as bold (and not blue) rather than blue (and not bold). Screenshot:

<img width="770" alt="Screenshot 2019-05-09 21 57 11" src="https://user-images.githubusercontent.com/796574/57503859-e85c2000-72a6-11e9-9594-36c46e1f2a74.png">

This PR also:
- Removes the `set -x` switch in the commands in the bakefile, since Bake already prints the commands
- Switches to using the `|-` string form for commands in the bakefile to trim the extra newline at the end

cc @juliahw