### PR TITLE
Pipe the command to the shell rather than passing it as an argument

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -29,7 +29,7 @@ pub fn run<R: Read>(
     }
 
     // Create a container to extract the files from.
-    let container = docker::create_container(to_image, "true", running)?;
+    let container = docker::create_container(to_image, running)?;
 
     // Delete the container when this function returns.
     defer! {{
@@ -87,11 +87,7 @@ pub fn run<R: Read>(
     }
 
     // Create the container.
-    let container = docker::create_container(
-      from_image,
-      &commands_to_run.join(" && "),
-      running,
-    )?;
+    let container = docker::create_container(from_image, running)?;
 
     // If the user interrupts the program, kill the container. The `unwrap`
     // will only fail if a panic already occurred.
@@ -118,7 +114,12 @@ pub fn run<R: Read>(
     }
 
     // Start the container to run the command.
-    docker::start_container(&container, running).map_err(|_| {
+    docker::start_container(
+      &container,
+      &commands_to_run.join(" && "),
+      running,
+    )
+    .map_err(|_| {
       if running.load(Ordering::SeqCst) {
         "Task failed."
       } else {


### PR DESCRIPTION
Pipe the command to the shell rather than passing it as an argument. The main advantage of doing this is that there is no concern about the command being too long to fit into a command-line argument.

Edit: We are still passing the user's command to `su` via the command-line, though, so that reduces the benefit of this change somewhat.