### PR TITLE
Fix a bug where Bake would try to copy an output file to a non-existent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Keep this file in sync with `.ignore`.
+artifacts/
 target/

--- a/.ignore
+++ b/.ignore
@@ -1,2 +1,3 @@
 # Keep this file in sync with `.gitignore`.
+artifacts/
 target/

--- a/bake.yml
+++ b/bake.yml
@@ -1,4 +1,5 @@
 image: ubuntu:18.04
+default: ci
 tasks:
   install_packages:
     command: |-
@@ -52,6 +53,7 @@ tasks:
       mv Cargo.lock.og Cargo.lock
       mv Cargo.toml.og Cargo.toml
       cargo build
+      cargo build --release
       cargo clippy
       rm -rf src
 
@@ -88,3 +90,24 @@ tasks:
       cargo fmt --all -- --check
       cargo clippy --all-targets --all-features -- --deny warnings --deny clippy::all --deny clippy::pedantic
       tagref
+
+  ci:
+    dependencies:
+      - build
+      - lint
+      - test
+
+  release:
+    dependencies:
+      - fetch_crates
+    input_paths:
+      - src
+    output_paths:
+      - artifacts
+    user: user
+    command: |-
+      set -euo pipefail
+      . $HOME/.cargo/env
+      cargo build --release
+      mkdir artifacts
+      cp target/release/bake artifacts/bake-x86_64-unknown-linux-gnu

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -214,7 +214,20 @@ pub fn copy_from_container(
       )
     };
     if metadata(&intermediate).map_err(metadata_err_map)?.is_file() {
-      // It's a file. Just move it to the destination.
+      // It's a file. Determine the destination directory. The `unwrap` is safe
+      // because the root of the filesystem cannot be a file.
+      let destination_dir = destination.parent().unwrap().to_owned();
+
+      // Make sure the destination directory exists.
+      create_dir_all(&destination_dir).map_err(|e| {
+        format!(
+          "Unable to create directory {}. Details: {}",
+          destination_dir.to_string_lossy().code_str(),
+          e
+        )
+      })?;
+
+      // Move it to the destination.
       rename(&intermediate, &destination).map_err(|e| {
         format!(
           "Unable to move file {} to destination {}. Details: {}",


### PR DESCRIPTION
Fix a bug where Bake would try to copy an output file to a non-existent directory. This PR also adds a new default `ci` target which does `build`, `lint`, and `test`, and also a new `release` target which produces a Linux binary. This will make the release process easier.