### PR TITLE
Fix the `fetch_crates` task

### DIFF
--- a/bake.yml
+++ b/bake.yml
@@ -53,7 +53,9 @@ tasks:
       mv Cargo.lock.og Cargo.lock
       mv Cargo.toml.og Cargo.toml
       cargo build
+      cargo clean --package bake
       cargo build --release
+      cargo clean --release --package bake
       cargo clippy
       rm -rf src
 


### PR DESCRIPTION
Fix the `fetch_crates` task. I noticed that Cargo was not rebuilding Bake in the `build` and `release` targets, even though the source files had correctly been copied into the container. So this change forces a rebuild by deleting the original (dummy) compiled artifacts.