### PR TITLE
Fix a minor bug in the way Bake handles child process death by signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2019-05-16
+
+### Fixed
+- Fixed a minor bug in the way Bake handles child processes that are killed by signals.
+
 ## [0.8.0] - 2019-05-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "bake"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bake"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 description = "A containerized build system."
 license = "MIT"

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -405,14 +405,15 @@ fn run_quiet(
   if output.status.success() {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
   } else {
-    Err(if running.load(Ordering::SeqCst) {
+    Err(if output.status.code().is_none() {
+      running.store(false, Ordering::SeqCst);
+      super::INTERRUPT_MESSAGE.to_owned()
+    } else {
       format!(
         "{}\nDetails: {}",
         error,
         String::from_utf8_lossy(&output.stderr)
       )
-    } else {
-      super::INTERRUPT_MESSAGE.to_owned()
     })
   }
 }
@@ -446,14 +447,15 @@ fn run_quiet_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), String>>(
   if output.status.success() {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
   } else {
-    Err(if running.load(Ordering::SeqCst) {
+    Err(if output.status.code().is_none() {
+      running.store(false, Ordering::SeqCst);
+      super::INTERRUPT_MESSAGE.to_owned()
+    } else {
       format!(
         "{}\nDetails: {}",
         error,
         String::from_utf8_lossy(&output.stderr)
       )
-    } else {
-      super::INTERRUPT_MESSAGE.to_owned()
     })
   }
 }
@@ -480,10 +482,11 @@ fn run_loud_stdin<W: FnOnce(&mut ChildStdin) -> Result<(), String>>(
     Ok(())
   } else {
     Err(
-      if running.load(Ordering::SeqCst) {
-        error
-      } else {
+      if status.code().is_none() {
+        running.store(false, Ordering::SeqCst);
         super::INTERRUPT_MESSAGE
+      } else {
+        error
       }
       .to_owned(),
     )
@@ -504,10 +507,11 @@ fn run_attach(
     Ok(())
   } else {
     Err(
-      if running.load(Ordering::SeqCst) {
-        error
-      } else {
+      if status.code().is_none() {
+        running.store(false, Ordering::SeqCst);
         super::INTERRUPT_MESSAGE
+      } else {
+        error
       }
       .to_owned(),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ extern crate log;
 extern crate scopeguard;
 
 // The program version
-const VERSION: &str = "0.8.0";
+const VERSION: &str = "0.9.0";
 
 // Defaults
 const BAKEFILE_DEFAULT_NAME: &str = "bake.yml";


### PR DESCRIPTION
Previously, when you hit CTRL+C, there would be a race between Bake and any child processes: if Bake receives the SIGINT first, it will exit gracefully. If on the other hand the child receives the SIGINT first and dies before Bake's signal handler has a chance to run, then Bake might incorrectly interpret the child failure to mean something important (e.g., it might conclude that a Docker image doesn't exist in a remote registry because `docker image pull` failed).

This situation is usually harmless, because shortly thereafter Bake's signal handler will run and Bake will gracefully exit, but it might have done a little more work before that point. The main concern is misleading output: Bake might tell the user that there was a cache miss (because it thinks a Docker image didn't exist), even though the image does exist but Docker was killed by the user while it was trying to pull the image.

I discovered that Rust makes it easy to check whether a child process was terminated by a signal (just check `exit_status.code().is_none()`). So now Bake will use that information to eliminate the bug caused by the race.

cc @juliahw