### PR TITLE
Don't use a login shell for --shell to match the behavior of tasks

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -378,7 +378,6 @@ pub fn spawn_shell(
       "--init", // [ref:--init]
       image,
       "/bin/su", // We use `su` rather than `sh` to use the root user's shell.
-      "-l",
     ],
     running,
   )


### PR DESCRIPTION
Don't use a login shell for `--shell` to match the behavior of tasks. I think this will lead to the least surprising behavior.

Bake doesn't use a login shell to run tasks because I don't think there is a portable way to run a user's login shell in an arbitrary directory (in our case, the task's `location`) without knowing in advance what the user's shell is. We can't assume that `cd` exists, for example. The user's shell might not be POSIX-compliant.

In the future, we might decide that Bake is allowed to assume some behavior about the user's shell. But for now, we just want to make sure that `--shell` is consistent with the way that Bake runs commands for tasks.