### PR TITLE
Spawn a shell on either success or failure if `--shell` is provided

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -35,7 +35,7 @@ pub fn image_exists(
 ) -> Result<bool, String> {
   debug!("Checking existence of image {}\u{2026}", image.code_str());
   if let Err(e) = run_quiet(
-    "Checking existence of image...",
+    "Checking existence of image\u{2026}",
     "The image doesn't exist.",
     &["image", "inspect", image],
     running,
@@ -57,7 +57,7 @@ pub fn push_image(
 ) -> Result<(), String> {
   debug!("Pushing image {}\u{2026}", image.code_str());
   run_quiet(
-    "Pushing image...",
+    "Pushing image\u{2026}",
     "Unable to push image.",
     &["image", "push", image],
     running,
@@ -72,7 +72,7 @@ pub fn pull_image(
 ) -> Result<(), String> {
   debug!("Pulling image {}\u{2026}", image.code_str());
   run_quiet(
-    "Pulling image...",
+    "Pulling image\u{2026}",
     "Unable to pull image.",
     &["image", "pull", image],
     running,
@@ -87,7 +87,7 @@ pub fn delete_image(
 ) -> Result<(), String> {
   debug!("Deleting image {}\u{2026}", image.code_str());
   run_quiet(
-    "Deleting image...",
+    "Deleting image\u{2026}",
     "Unable to delete image.",
     &["image", "rm", "--force", image],
     running,
@@ -113,7 +113,7 @@ pub fn create_container(
   // the child process (in our case, `/bin/sh`) works normally. [tag:--init]
   Ok(
     run_quiet(
-      "Creating container...",
+      "Creating container\u{2026}",
       "Unable to create container.",
       vec![
         "container",
@@ -142,7 +142,7 @@ pub fn copy_into_container<R: Read>(
     container.code_str()
   );
   run_quiet_stdin(
-    "Copying files into container...",
+    "Copying files into container\u{2026}",
     "Unable to copy files into the container.",
     &["container", "cp", "-", &format!("{}:{}", container, "/")],
     |mut stdin| {
@@ -195,7 +195,7 @@ pub fn copy_from_container(
 
     // Get the path from the container.
     run_quiet(
-      "Copying files from the container...",
+      "Copying files from the container\u{2026}",
       "Unable to copy files from the container.",
       &[
         "container",
@@ -317,7 +317,7 @@ pub fn stop_container(
 ) -> Result<(), String> {
   debug!("Stopping container {}\u{2026}", container.code_str());
   run_quiet(
-    "Stopping container...",
+    "Stopping container\u{2026}",
     "Unable to stop container.",
     &["container", "stop", container],
     running,
@@ -337,7 +337,7 @@ pub fn commit_container(
     image.code_str()
   );
   run_quiet(
-    "Committing container...",
+    "Committing container\u{2026}",
     "Unable to commit container.",
     &["container", "commit", container, image],
     running,
@@ -352,7 +352,7 @@ pub fn delete_container(
 ) -> Result<(), String> {
   debug!("Deleting container {}\u{2026}", container.code_str());
   run_quiet(
-    "Deleting container...",
+    "Deleting container\u{2026}",
     "Unable to delete container.",
     &["container", "rm", "--force", container],
     running,


### PR DESCRIPTION
Spawn a shell on either success or failure if `--shell` is provided. This is useful for debugging failed tasks. Previously, `--shell` would only take effect if all the tasks succeeded.

Unfortunately this was quite an ugly change! One of the downsides of Rust's ownership-tracking type system is that I was unable to write nice-looking code like this:

```rust
let foo = bar.map_err(|e| (e, context))?;
```

The problem occurs when `context` is used later in the function. The borrow checker has no way to know that when this lambda is executed, we're in the error case and the `?` will cause the function to immediately return. I can't just `clone` the `context` because `Context` doesn't implement the `Clone` trait (for good reason).

So I had to write this instead:

```rust
let foo = match bar {
  Ok(foo) => foo,
  Err(e) => return Err((e, context)),
};
```

When the code is written in this uglier style, the borrow checker is smart enough to realize that it's okay to consume `context` in this branch since any subsequent uses of it in this function will not be reached.

@juliahw