### PR TITLE
Use a new format for the cache key

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -35,7 +35,7 @@ pub fn key(
     cache_key = extend(&cache_key, &command);
   }
 
-  cache_key[..48].to_owned()
+  format!("bake-{}", cache_key)
 }
 
 // Compute the hash of a readable object (e.g., a file). This function does not

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,9 +457,9 @@ fn run_tasks(
   // variable will be permanently set to `false`.
   let mut caching_enabled = true;
 
-  // This is the cache key for the current task. We initialize it with a hash
-  // of the base image name.
-  let mut cache_key = cache::hash_str(&bakefile.image);
+  // This is the cache key for the current task. We initialize it with the base
+  // image name.
+  let mut cache_key = bakefile.image.clone();
 
   // The context is either an image or a container. We start with an image.
   let mut context = runner::Context::Image(bakefile.image.clone());


### PR DESCRIPTION
Fundamentally, our cache keys are SHA-256 hash digests. But 256 bits is 64 hexadecimal bytes, and Docker has a [rule](https://github.com/moby/moby/issues/20972) that tags cannot look like 64-byte hexadecimal strings:

Prior to this PR, the workaround was to use only the first 48 bytes of the string. But the idea of reducing the entropy of the hash function never sat well with me. This PR changes the logic to use all 64 bytes, but prefixed with `bake-`.

This will invalidate every cache key. Better rip the bandaid off now before we announce the launch!

@juliahw