### PR TITLE
Extract the spinner animation logic into a general-purpose module

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,7 +1,4 @@
-use crate::format::CodeStr;
-use crossbeam::channel::{bounded, Sender};
-use indicatif::{ProgressBar, ProgressStyle};
-use scopeguard::guard;
+use crate::{format::CodeStr, spinner::spin};
 use std::{
   fs::{create_dir_all, metadata, rename},
   io,
@@ -13,9 +10,6 @@ use std::{
     atomic::{AtomicBool, Ordering},
     Arc,
   },
-  thread,
-  thread::sleep,
-  time::{Duration, Instant},
 };
 use tempfile::tempdir;
 use uuid::Uuid;
@@ -522,83 +516,6 @@ fn command(args: &[&str]) -> Command {
     command.arg(arg);
   }
   command
-}
-
-// Render a spinner in the terminal. When the returned value is dropped, the
-// spinner is stopped.
-fn spin(message: &str) -> impl Drop {
-  // Start a thread for our spinner-as-a-service. This thread will only be
-  // created once and will live for the duration of the whole program.
-  lazy_static! {
-    static ref SPINNER_SERVICE: Sender<(String, Arc<AtomicBool>, Sender<()>)> = {
-      // Create a channel for requests to start spinning.
-      let (request_sender, request_receiver) =
-        bounded::<(String, Arc<AtomicBool>, Sender<()>)>(0);
-
-      // Start a thread to handle spinner requests.
-      thread::spawn(move || loop {
-        // Wait for a request. The `unwrap` is safe since we never hang up the
-        // channel.
-        let (message, spinning, response_sender) =
-          request_receiver.recv().unwrap();
-
-        // Create the spinner!
-        let spinner = ProgressBar::new(1);
-        spinner.set_style(ProgressStyle::default_spinner());
-        spinner.set_message(&message);
-
-        // Animate the spinner for as long as necessary.
-        let now = Instant::now();
-        while spinning.load(Ordering::SeqCst) {
-          // Render the next frame of the spinner.
-          spinner.tick();
-
-          // For the first 100ms, we animate on a shorter time interval so we
-          // can stop faster if the work finishes instantly. If the work takes
-          // longer than that, we slow the animation down out of courtesy for
-          // the CPU.
-          if now.elapsed() < Duration::from_millis(100) {
-            sleep(Duration::from_millis(16));
-          } else {
-            sleep(Duration::from_millis(100));
-          }
-        }
-
-        // Clean up the spinner.
-        spinner.finish_and_clear();
-
-        // Inform the caller that the spinner has been cleaned up. The `unwrap`
-        // is safe since we never hang up the channel.
-        response_sender.send(()).unwrap();
-      });
-
-      // The sender half of the request channel is the API for this spinner
-      // service. Return it.
-      request_sender
-    };
-  }
-
-  // Create a channel for waiting on the spinner.
-  let (response_sender, response_receiver) = bounded::<()>(0);
-
-  // This will be set to `false` when it's time to stop the spinner.
-  let spinning = Arc::new(AtomicBool::new(true));
-
-  // Create and animate the spinner. The `unwrap` is safe since we never hang
-  // up the channel.
-  SPINNER_SERVICE
-    .send((message.to_owned(), spinning.clone(), response_sender))
-    .unwrap();
-
-  // Return a guard that stops the spinner via its destructor.
-  guard((), move |_| {
-    // Tell the spinner service to stop the spinner.
-    spinning.store(false, Ordering::SeqCst);
-
-    // Wait for the spinner to stop. The `unwrap` is safe since we never hang
-    // up the channel.
-    response_receiver.recv().unwrap();
-  })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod docker;
 mod format;
 mod runner;
 mod schedule;
+mod spinner;
 mod tar;
 
 use crate::format::CodeStr;
@@ -485,10 +486,12 @@ fn run_tasks(
     let mut bakefile_dir = PathBuf::from(&settings.bakefile_path);
     bakefile_dir.pop();
     let (mut tar_file, input_files_hash) = match tar::create(
+      "Reading files\u{2026}",
       tar_file,
       &task_data.input_paths,
       &bakefile_dir,
       &task_data.location,
+      &interrupted,
     ) {
       Ok((tar_file, input_files_hash)) => (tar_file, input_files_hash),
       Err(e) => return Err((e, context)),

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -1,0 +1,89 @@
+use crossbeam::channel::{bounded, Sender};
+use indicatif::{ProgressBar, ProgressStyle};
+use scopeguard::guard;
+use std::{
+  sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+  },
+  thread,
+  thread::sleep,
+  time::{Duration, Instant},
+};
+
+// Render a spinner in the terminal. When the returned value is dropped, the
+// spinner is stopped.
+pub fn spin(message: &str) -> impl Drop {
+  // Start a thread for our spinner-as-a-service. This thread will only be
+  // created once and will live for the duration of the whole program.
+  lazy_static! {
+    static ref SPINNER_SERVICE: Sender<(String, Arc<AtomicBool>, Sender<()>)> = {
+      // Create a channel for requests to start spinning.
+      let (request_sender, request_receiver) =
+        bounded::<(String, Arc<AtomicBool>, Sender<()>)>(0);
+
+      // Start a thread to handle spinner requests.
+      thread::spawn(move || loop {
+        // Wait for a request. The `unwrap` is safe since we never hang up the
+        // channel.
+        let (message, spinning, response_sender) =
+          request_receiver.recv().unwrap();
+
+        // Create the spinner!
+        let spinner = ProgressBar::new(1);
+        spinner.set_style(ProgressStyle::default_spinner());
+        spinner.set_message(&message);
+
+        // Animate the spinner for as long as necessary.
+        let now = Instant::now();
+        while spinning.load(Ordering::SeqCst) {
+          // Render the next frame of the spinner.
+          spinner.tick();
+
+          // For the first 100ms, we animate on a shorter time interval so we
+          // can stop faster if the work finishes instantly. If the work takes
+          // longer than that, we slow the animation down out of courtesy for
+          // the CPU.
+          if now.elapsed() < Duration::from_millis(100) {
+            sleep(Duration::from_millis(16));
+          } else {
+            sleep(Duration::from_millis(100));
+          }
+        }
+
+        // Clean up the spinner.
+        spinner.finish_and_clear();
+
+        // Inform the caller that the spinner has been cleaned up. The `unwrap`
+        // is safe since we never hang up the channel.
+        response_sender.send(()).unwrap();
+      });
+
+      // The sender half of the request channel is the API for this spinner
+      // service. Return it.
+      request_sender
+    };
+  }
+
+  // Create a channel for waiting on the spinner.
+  let (response_sender, response_receiver) = bounded::<()>(0);
+
+  // This will be set to `false` when it's time to stop the spinner.
+  let spinning = Arc::new(AtomicBool::new(true));
+
+  // Create and animate the spinner. The `unwrap` is safe since we never hang
+  // up the channel.
+  SPINNER_SERVICE
+    .send((message.to_owned(), spinning.clone(), response_sender))
+    .unwrap();
+
+  // Return a guard that stops the spinner via its destructor.
+  guard((), move |_| {
+    // Tell the spinner service to stop the spinner.
+    spinning.store(false, Ordering::SeqCst);
+
+    // Wait for the spinner to stop. The `unwrap` is safe since we never hang
+    // up the channel.
+    response_receiver.recv().unwrap();
+  })
+}


### PR DESCRIPTION
Extract the spinner animation logic into a general-purpose module. The `tar` module is its newest customer. I realized that tarring can sometimes take a long time if there is a lot of data to read, so we should show a spinner during that. I also added some logic to enable the tarring operation to be interrupted by the user.