### PR TITLE
Don't bother actually running tasks that don't do anything

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -13,6 +13,12 @@ pub fn key(
   // Start with the previous key.
   let mut cache_key = previous_key.to_owned();
 
+  // If there are no input paths and no command to run, we can just use the
+  // cache key from the previous task.
+  if task.input_paths.is_empty() && task.command.is_none() {
+    return cache_key;
+  }
+
   // Environment variables
   let mut variables = task.environment.keys().collect::<Vec<_>>();
   variables.sort();


### PR DESCRIPTION
Don't bother actually running tasks that don't do anything. Sometimes it's useful to have tasks that only exist to group their dependencies. For example, in Bake's bakefile, I have this task:

```yaml
  ci:
    dependencies:
      - build
      - lint
      - test
```

There's no point in actually creating containers and images for that task. So this PR introduces a convenient optimization to essentially do nothing for these tasks (other than running their dependencies).

@juliahw