### PR TITLE
Inform the user when Docker isn't installed

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -52,7 +52,7 @@ pub fn key(
 pub fn hash_read<R: Read>(input: &mut R) -> Result<String, String> {
   let mut hasher = Sha256::new();
   io::copy(input, &mut hasher)
-    .map_err(|e| format!("Unable to compute hash. Details: {}", e))?;
+    .map_err(|e| format!("Unable to compute hash. Details: {}.", e))?;
   Ok(hex::encode(hasher.result()))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn set_up_signal_handlers(
       let _ = stdout().write(b"\n");
     }
   })
-  .map_err(|e| format!("Error installing signal handler. Details: {}", e))
+  .map_err(|e| format!("Error installing signal handler. Details: {}.", e))
 }
 
 // Convert a string (from a command-line argument) into a Boolean.
@@ -233,7 +233,7 @@ fn settings() -> Result<Settings, String> {
   let bakefile_path = matches.value_of(BAKEFILE_ARG).map_or_else(
     || {
       let mut candidate_dir = current_dir().map_err(|e| {
-        format!("Unable to determine working directory. Details: {}", e)
+        format!("Unable to determine working directory. Details: {}.", e)
       })?;
       loop {
         let candidate_path = candidate_dir.join(BAKEFILE_DEFAULT_NAME);
@@ -344,7 +344,7 @@ fn parse_bakefile(bakefile_path: &Path) -> Result<bakefile::Bakefile, String> {
   // Read the file from disk.
   let bakefile_data = fs::read_to_string(bakefile_path).map_err(|e| {
     format!(
-      "Unable to read file {}. Details: {}",
+      "Unable to read file {}. Details: {}.",
       bakefile_path.to_string_lossy().code_str(),
       e
     )

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -97,7 +97,7 @@ pub fn run(
     Ok(tar_file) => tar_file,
     Err(e) => {
       return Err((
-        format!("Unable to create temporary file. Details: {}", e),
+        format!("Unable to create temporary file. Details: {}.", e),
         context,
       ))
     }
@@ -120,7 +120,7 @@ pub fn run(
   // the container.
   if let Err(e) = tar_file.seek(SeekFrom::Start(0)) {
     return Err((
-      format!("Unable to seek temporary file. Details: {}", e),
+      format!("Unable to seek temporary file. Details: {}.", e),
       context,
     ));
   };
@@ -303,7 +303,7 @@ pub fn run(
     // Set up a filesystem watcher.
     let mut watcher = match watcher(notify_sender, Duration::from_millis(200))
       .map_err(|e| {
-        format!("Unable to initialize filesystem watcher. Details: {}", e)
+        format!("Unable to initialize filesystem watcher. Details: {}.", e)
       }) {
       Ok(watcher) => watcher,
       Err(e) => {
@@ -328,7 +328,7 @@ pub fn run(
           let tar_file = match tempfile() {
             Ok(tar_file) => tar_file,
             Err(e) => {
-              error!("Unable to create temporary file. Details: {}", e);
+              error!("Unable to create temporary file. Details: {}.", e);
               break;
             }
           };
@@ -352,7 +352,7 @@ pub fn run(
           // Seek back to the beginning of the archive to prepare for copying
           // it into the container.
           if let Err(e) = tar_file.seek(SeekFrom::Start(0)) {
-            error!("Unable to seek temporary file. Details: {}", e);
+            error!("Unable to seek temporary file. Details: {}.", e);
             break;
           };
 
@@ -377,7 +377,7 @@ pub fn run(
         if let Err(e) = watcher.watch(path, RecursiveMode::Recursive) {
           return Err((
             format!(
-              "Unable to register a filesystem watch path. Details: {}",
+              "Unable to register a filesystem watch path. Details: {}.",
               e
             ),
             context,

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -62,7 +62,7 @@ pub fn create<W: Write>(
   // with respect to it.
   let source_dir = source_dir.canonicalize().map_err(|e| {
     format!(
-      "Unable to canonicalize path {}. Details: {}",
+      "Unable to canonicalize path {}. Details: {}.",
       source_dir.to_string_lossy().code_str(),
       e
     )
@@ -102,7 +102,7 @@ pub fn create<W: Write>(
       // Unwrap the entry.
       let entry = entry.map_err(|e| {
         format!(
-          "Unable to traverse path {}. Details: {}",
+          "Unable to traverse path {}. Details: {}.",
           &absolute_input_path.to_string_lossy().code_str(),
           e
         )
@@ -111,7 +111,7 @@ pub fn create<W: Write>(
       // Fetch the metadata for this entry.
       let entry_metadata = entry.metadata().map_err(|e| {
         format!(
-          "Unable to fetch filesystem metadata for {}. Details: {}",
+          "Unable to fetch filesystem metadata for {}. Details: {}.",
           &absolute_input_path.to_string_lossy().code_str(),
           e
         )
@@ -120,7 +120,7 @@ pub fn create<W: Write>(
       // Fetch the host path.
       let absolute_host_path = entry.path().canonicalize().map_err(|e| {
         format!(
-          "Unable to canonicalize path {}. Details: {}",
+          "Unable to canonicalize path {}. Details: {}.",
           &entry.path().to_string_lossy().code_str(),
           e
         )
@@ -131,7 +131,7 @@ pub fn create<W: Write>(
         .strip_prefix(&source_dir)
         .map_err(|e| {
           format!(
-            "Unable to relativize path {} with respect to {}. Details: {}",
+            "Unable to relativize path {} with respect to {}. Details: {}.",
             &entry.path().to_string_lossy().code_str(),
             &source_dir.to_string_lossy().code_str(),
             e
@@ -149,7 +149,7 @@ pub fn create<W: Write>(
         // It's a file. Open it so we can compute the hash of its contents.
         let mut file = File::open(&absolute_host_path).map_err(|e| {
           format!(
-            "Unable to open file {}. Details: {}",
+            "Unable to open file {}. Details: {}.",
             &absolute_host_path.to_string_lossy().code_str(),
             e
           )
@@ -167,7 +167,7 @@ pub fn create<W: Write>(
         // Jump back to the beginning of the file so the tar builder can read it.
         file.seek(SeekFrom::Start(0)).map_err(|e| {
           format!(
-            "Unable to seek file {}. Details: {}",
+            "Unable to seek file {}. Details: {}.",
             &absolute_host_path.to_string_lossy().code_str(),
             e
           )
@@ -207,7 +207,7 @@ pub fn create<W: Write>(
   Ok((
     builder
       .into_inner()
-      .map_err(|e| format!("Error writing tar archive. Details: {}", e))?,
+      .map_err(|e| format!("Error writing tar archive. Details: {}.", e))?,
     file_hashes
       .iter()
       .fold(cache::hash_str(""), |acc, x| cache::extend(&acc, x)),


### PR DESCRIPTION
Inform the user when Docker isn't installed. I also added punctuation to all error messages produced by libraries, because the convention is for error messages to not have punctuation. However, all the error messages I write have punctuation, because that convention is more expressive (the message can include questions, exclamatory remarks, etc.).